### PR TITLE
Add AK contact details

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,9 +10,9 @@ humandate: "Jan 10-11, 2019"    # human-readable dates for the workshop (e.g., "
 humantime: "09:00 - 17:00"    # human-readable times for the workshop (e.g., "9:00 am - 4:30 pm")
 startdate: 2019-01-10      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
 enddate: 2019-01-11        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
-instructor: ["Malvika Sharan, Toby Hodges, Fotis E. Psomopoulos"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
+instructor: ["Malvika Sharan", "Anna Krystalli", "Fotis E. Psomopoulos"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
 helper: ["TBC"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
-email: ["malvika.sharan@embl.de, tbyhdgs@gmail.com, fopsom@gmail.com"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
+email: ["malvika.sharan@embl.de", "a.krystalli@sheffield.ac.uk", "fopsom@gmail.com"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
 collaborative_notes: https://pad.carpentries.org/2019-01-10-elixir-athens             # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document
 eventbrite: 52153548668          # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
 ---


### PR DESCRIPTION
Was going to do a direct commit but I also edited the format of the name/email entries to comma separated individual strings as suggested. Just wanted to double-check there wasn't a reason they were in a single string. Feel free to change back.


